### PR TITLE
Remove printing "volgroup" statements in Anaconda.

### DIFF
--- a/src/main/perl/LVM.pm
+++ b/src/main/perl/LVM.pm
@@ -311,7 +311,6 @@ sub print_ks
     return unless $self->should_print_ks;
 
     $_->print_ks foreach (@{$self->{device_list}});
-    print "\nvolgroup $self->{devname} --noformat\n";
 }
 
 =pod


### PR DESCRIPTION
They don't work anymore on SL6.3.
