### PR TITLE
Fix software RAID for SL6

### DIFF
--- a/src/main/perl/MD.pm
+++ b/src/main/perl/MD.pm
@@ -282,7 +282,7 @@ EOF
     }
     my $ndev = scalar(@devnames);
     print <<EOC;
-    mdadm --create --run $path --level=$self->{raid_level} \\
+    sleep 5; mdadm --create --run $path --level=$self->{raid_level} --metadata=0.90 \\
         --chunk=$self->{stripe_size} --raid-devices=$ndev \\
          @devnames
     echo @{[$self->devpath]} >> @{[PART_FILE]}


### PR DESCRIPTION
In SL6 some of the partitioning tools have changed and mdadm was not able to assemble the partitions.
This fix forces it to  use 0.9 metadata and gives it 5 sec. between operations.
This has been tested with SL5 and SL6 with RAID and non-RAID.
