### PR TITLE
treat -1 same as 100% when defined as the end of a partition

### DIFF
--- a/src/main/perl/Partition.pm
+++ b/src/main/perl/Partition.pm
@@ -489,7 +489,7 @@ then
         # The first partition must be aligned to the first MiB (0%)
         prev=1
     fi
-    if [ $size = '100%'  ]
+    if [ $size = '100%'  ] || [ $size = -1 ]
     then
         end=$size
     else


### PR DESCRIPTION
There is a significant amount of legacy configuration that assumes that -1 means use all available free space when given as the end of the partition. The installation tools (parted) support this. It may be simpler to just get rid of the legacy code, but I am not sure how easy is this in sites that may have old 5.x systems still in use.
