### PR TITLE
add sleep 5 before running mdadm

### DIFF
--- a/src/main/perl/MD.pm
+++ b/src/main/perl/MD.pm
@@ -282,7 +282,7 @@ EOF
     }
     my $ndev = scalar(@devnames);
     print <<EOC;
-    mdadm --create --run $path --level=$self->{raid_level} \\
+    sleep 5 ; mdadm --create --run $path --level=$self->{raid_level} \\
         --chunk=$self->{stripe_size} --raid-devices=$ndev \\
          @devnames
     echo @{[$self->devpath]} >> @{[PART_FILE]}


### PR DESCRIPTION
In our SL6 systems we had to add a small delay before running mdadm for installation to work, else it fails to create (some of?) the software raid arrays.
