### PR TITLE
Fix bug in create_if_needed

### DIFF
--- a/src/main/perl/Filesystem.pm
+++ b/src/main/perl/Filesystem.pm
@@ -204,7 +204,7 @@ sub formatfs
     # Format only if there must be a filesystem. After a
     # re-install, it can happen that $self->{format} is false and
     # the block device has a filesystem. Dont' destroy the data.
-    if ($self->{type} ne 'none' || !$self->{block_device}->has_filesystem) {
+    if ($self->{type} ne 'none' && !$self->{block_device}->has_filesystem) {
 	$this_app->debug (5, "Formatting to get $self->{mountpoint}");
 	CAF::Process->new ([MKFSCMDS->{$self->{type}}, @opts,
 			    $self->{block_device}->devpath],


### PR DESCRIPTION
Closes #12.

The logic is as follows:
- If the FS is "none", there is NOTHING to format. Period.
- If the FS is something else, we format it IFF it the block device doesn't have it yet.

As discussed with @stdweird on Friday, the new feature to enforce the filesystem (e.g, to (optionally) re-format an ext4 device into XFS if the profile states so) is a different improvement, that will be welcome when it gets tests.
