### PR TITLE
Require parted binary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
 	  </provides>
 	  <requires>
 	    <require>ncm-ncd</require>
+	    <require>/sbin/parted</require>
 	  </requires>
 
 	  <mappings>


### PR DESCRIPTION
BlockdevFactory and Partition both make of it.
Fixes #20.
