### PR TITLE
Filesystem: add uuid support, and strict protected mountpoints or filesystems

### DIFF
--- a/src/main/perl/Blockdevices.pm
+++ b/src/main/perl/Blockdevices.pm
@@ -15,6 +15,7 @@ use EDG::WP4::CCM::Configuration;
 use CAF::Object;
 use CAF::Process;
 use Exporter;
+use constant BLKID	=> "/sbin/blkid";
 use constant FILES => qw (file -s);
 
 use constant PART_FILE  => '/tmp/created_partitions';
@@ -27,7 +28,7 @@ our @ISA = qw/CAF::Object Exporter/;
 
 our $this_app = $main::this_app;
 
-our @EXPORT_OK = qw ($this_app PART_FILE);
+our @EXPORT_OK = qw ($this_app PART_FILE get_disk_uuid);
 
 sub get_cache_key {
      my ($self, $path, $config) = @_;
@@ -463,6 +464,28 @@ sub has_filesystem
     # case insensitive match 
     # e.g. file -s returns uppercase filesystem for xfs adn btrfs
     return $f =~ m{\s$fsregex\s+file}i;
+}
+
+=pod
+
+=head2 get_disk_uuid
+
+Fetches the (PART)UUID of the device with blkid. Returns undef when not found.
+type can be an empty string or 'PART'
+
+=cut
+
+sub get_disk_uuid
+{
+    my ($self, $type, $device) = @_;
+    
+    my $output = CAF::Process->new([BLKID, $device], log => $this_app)->output();
+    if($type =~ m/^(PART)?$/) {
+        my $re = qr!\s${type}UUID="(\S+)"!m ;
+        if($output && $output =~ m/$re/m){
+        return $1;
+        }
+    }
 }
 
 1;

--- a/src/main/perl/Blockdevices.pm
+++ b/src/main/perl/Blockdevices.pm
@@ -471,24 +471,23 @@ sub has_filesystem
 =head2 get_uuid
 
 Fetches the (PART)UUID of the device with blkid. Returns undef when not found.
-type can be an empty string or 'PART'
+If part is true, we use PARTUUID instead of UUID
 
 =cut
 
 sub get_uuid
 {
-    my ($self, $type) = @_;
+    my ($self, $part) = @_;
     my $device = $self->devpath; 
     my $uuid;
     my $output = CAF::Process->new([BLKID, $device], log => $this_app)->output();
-    if($type =~ m/^(PART)?$/) {
-        my $re = qr!\s${type}UUID="(\S+)"!m ;
-        if($output && $output =~ m/$re/m){
-            $uuid = $1;
-        }
+    $part = $part ? 'PART' : '';
+    my $re = qr!\s${part}UUID="(\S+)"!m ;
+    if($output && $output =~ m/$re/m){
+        $uuid = $1;
     }
     if (!defined($uuid)){
-        $this_app->warn("${type}UUID of device $device could not be found");
+        $this_app->warn("${part}UUID of device $device could not be found");
     }
     return $uuid;
 }

--- a/src/main/perl/Blockdevices.pm
+++ b/src/main/perl/Blockdevices.pm
@@ -15,7 +15,7 @@ use EDG::WP4::CCM::Configuration;
 use CAF::Object;
 use CAF::Process;
 use Exporter;
-use constant BLKID	=> "/sbin/blkid";
+use constant BLKID => "/sbin/blkid";
 use constant FILES => qw (file -s);
 
 use constant PART_FILE  => '/tmp/created_partitions';
@@ -28,7 +28,7 @@ our @ISA = qw/CAF::Object Exporter/;
 
 our $this_app = $main::this_app;
 
-our @EXPORT_OK = qw ($this_app PART_FILE get_disk_uuid);
+our @EXPORT_OK = qw ($this_app PART_FILE);
 
 sub get_cache_key {
      my ($self, $path, $config) = @_;
@@ -468,24 +468,29 @@ sub has_filesystem
 
 =pod
 
-=head2 get_disk_uuid
+=head2 get_uuid
 
 Fetches the (PART)UUID of the device with blkid. Returns undef when not found.
 type can be an empty string or 'PART'
 
 =cut
 
-sub get_disk_uuid
+sub get_uuid
 {
-    my ($self, $type, $device) = @_;
-    
+    my ($self, $type) = @_;
+    my $device = $self->devpath; 
+    my $uuid;
     my $output = CAF::Process->new([BLKID, $device], log => $this_app)->output();
     if($type =~ m/^(PART)?$/) {
         my $re = qr!\s${type}UUID="(\S+)"!m ;
         if($output && $output =~ m/$re/m){
-        return $1;
+            $uuid = $1;
         }
     }
+    if (!defined($uuid)){
+        $this_app->warn("${type}UUID of device $device could not be found");
+    }
+    return $uuid;
 }
 
 1;

--- a/src/main/perl/Filesystem.pm
+++ b/src/main/perl/Filesystem.pm
@@ -250,7 +250,6 @@ sub update_fstab
     my ($self, $fh, $pstrict) = @_;
 
     use Test::More;
-    diag "in";
     my $close_fh = 1;
     if(ref($fh) eq 'CAF::FileEditor') {
         # TODO check if not closed?
@@ -260,10 +259,8 @@ sub update_fstab
     } else {
         $fh = CAF::FileEditor->new (FSTAB, log => $this_app, backup => '.old');
     };
-    diag "fh $fh";
 
     my $ok_device = $self->check_in_fstab($fh, $pstrict);
-    diag "after check $fh";
     if ($ok_device) {
         my $entry = join ("\t",
                         $ok_device,
@@ -282,9 +279,7 @@ sub update_fstab
                                ENDING_OF_FILE);
 
     } 
-    diag "before iclose$fh";
     $fh->close() if $close_fh;
-    diag "after iclose$fh";
     
 }
 

--- a/src/test/perl/filesystem.t
+++ b/src/test/perl/filesystem.t
@@ -19,6 +19,7 @@ use CAF::FileEditor;
 use CAF::Object;
 
 my $cfg = get_config_for_profile('filesystem');
+$CAF::Object::NoAction = 1;
 
 set_disks({sdb => 1});
 

--- a/src/test/perl/fstab-strict.t
+++ b/src/test/perl/fstab-strict.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl 
+# -*- mode: cperl -*-
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
+use strict;
+use warnings;
+use Test::More;
+use NCM::Filesystem;
+use CAF::Object;
+use Test::Quattor qw(fstab);
+
+use helper; 
+
+my $cfg = get_config_for_profile('fstab');
+
+$CAF::Object::NoAction = 1;
+# regular fs test
+my $fs0 = NCM::Filesystem->new ("/system/filesystems/0", $cfg);
+my $fs1 = NCM::Filesystem->new ("/system/filesystems/1", $cfg);
+my $fs2 = NCM::Filesystem->new ("/system/filesystems/2", $cfg);
+my $fs3 = NCM::Filesystem->new ("/system/filesystems/3", $cfg);
+
+# set empty fstab
+set_file("fstab_default");
+
+my $protected = {
+    mounts => {
+        '/Lagoon2' => 1, 
+        '/Lagoon3' => 1,
+    },
+    filesystems => {
+        'xfs' => 1,
+    },
+};
+
+#not protected
+$fs0->update_fstab(undef, $protected);
+like(get_file('/etc/fstab'), qr{^/dev/sdb1\s+/Lagoon\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 'Mount fs0 entry added to fstab');
+
+set_desired_output('/sbin/blkid /dev/sdb2', 
+    '/dev/sdb2: UUID="3ba76f19-ce89-4f33-a818-2d5e34678830" TYPE="ext3" PARTUUID="069218b3-02"');
+
+#protected mountpoint
+$fs1->update_fstab(undef, $protected);
+like(get_file('/etc/fstab'), qr{^UUID=3ba76f19-ce89-4f33-a818-2d5e34678830\s+/Lagoon2\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs1 entry added to fstab');
+
+set_desired_output('/sbin/blkid /dev/sdb3', 
+    '/dev/sdb3: UUID="f1b57f63-b545-44b5-b5c0-a24c578e0613" TYPE="ext3" PARTUUID="069218b3-02"');
+#protected mointpoint
+$fs2->update_fstab(undef, $protected);
+like(get_file('/etc/fstab'), qr{^UUID=f1b57f63-b545-44b5-b5c0-a24c578e0613\s+/Lagoon3\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs2 entry added to fstab');
+
+#protected type
+$fs3->update_fstab(undef, $protected);
+like(get_file('/etc/fstab'), qr{^LABEL=FSLAB\s+/Lagoon4\s+xfs\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs3 entry added to fstab');
+
+# Now do it again! 
+my $newtxt = get_file('/etc/fstab'); #otherwise Can't coerce GLOB to string in substr 
+$newtxt =~ s!^/dev/sdb1!/dev/sdc1!m;
+$newtxt =~ s!^UUID=f1b57f63-b545-44b5-b5c0-a24c578e0613!UUID=7d03ea2f-8fa0-4cf6-ac30-4c98216420a0!m;
+$newtxt =~ s!^LABEL=FSLAB!/dev/sdd1!m;
+set_file("fstab_default","$newtxt");
+#Different devpath in file
+$fs0->update_fstab(undef, $protected);
+#Same
+$fs1->update_fstab(undef, $protected);
+#Different UUID 7d03ea2f-8fa0-4cf6-ac30-4c98216420a0 in file
+$fs2->update_fstab(undef, $protected);
+$fs3->update_fstab(undef, $protected);
+like(get_file('/etc/fstab'), qr{^/dev/sdb1\s+/Lagoon\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs0 entry changed in fstab');
+like(get_file('/etc/fstab'), qr{^UUID=3ba76f19-ce89-4f33-a818-2d5e34678830\s+/Lagoon2\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs1 protected in fstab');
+like(get_file('/etc/fstab'), qr{^UUID=7d03ea2f-8fa0-4cf6-ac30-4c98216420a0\s+/Lagoon3\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs2 protected in fstab');
+like(get_file('/etc/fstab'), qr{^/dev/sdd1\s+/Lagoon4\s+xfs\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs3 type protected in fstab');
+
+done_testing();

--- a/src/test/perl/fstab-strict.t
+++ b/src/test/perl/fstab-strict.t
@@ -38,7 +38,8 @@ my $protected = {
 
 #not protected
 $fs0->update_fstab(undef, $protected);
-like(get_file('/etc/fstab'), qr{^/dev/sdb1\s+/Lagoon\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 'Mount fs0 entry added to fstab');
+like(get_file('/etc/fstab'), qr{^/dev/sdb1\s+/Lagoon\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs0 entry added to fstab');
 
 set_desired_output('/sbin/blkid /dev/sdb2', 
     '/dev/sdb2: UUID="3ba76f19-ce89-4f33-a818-2d5e34678830" TYPE="ext3" PARTUUID="069218b3-02"');

--- a/src/test/perl/fstab-strict.t
+++ b/src/test/perl/fstab-strict.t
@@ -31,7 +31,7 @@ my $protected = {
         '/Lagoon2' => 1, 
         '/Lagoon3' => 1,
     },
-    filesystems => {
+    fs_types => {
         'xfs' => 1,
     },
 };

--- a/src/test/perl/fstab-uuid.t
+++ b/src/test/perl/fstab-uuid.t
@@ -1,0 +1,77 @@
+#!/usr/bin/perl 
+# -*- mode: cperl -*-
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
+use strict;
+use warnings;
+use Test::More;
+use NCM::Filesystem;
+use CAF::Object;
+use Test::Quattor qw(fstab);
+
+use helper; 
+
+my $cfg = get_config_for_profile('fstab');
+
+$CAF::Object::NoAction = 1;
+# regular fs test
+my $fs0 = NCM::Filesystem->new ("/system/filesystems/0", $cfg);
+my $fs1 = NCM::Filesystem->new ("/system/filesystems/1", $cfg);
+my $fs2 = NCM::Filesystem->new ("/system/filesystems/2", $cfg);
+my $fs3 = NCM::Filesystem->new ("/system/filesystems/3", $cfg);
+
+# set empty fstab
+set_file("fstab_default");
+
+# no match uuid or label
+$fs0->update_fstab;
+like(get_file('/etc/fstab'), qr{^/dev/sdb1\s+/Lagoon\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 'Mount fs0 entry added to fstab');
+
+set_desired_output('/sbin/blkid /dev/sdb2', 
+    '/dev/sdb2: UUID="3ba76f19-ce89-4f33-a818-2d5e34678830" TYPE="ext3" PARTUUID="069218b3-02"');
+#use uuid 3ba76f19-ce89-4f33-a818-2d5e34678830
+$fs1->update_fstab;
+like(get_file('/etc/fstab'), qr{^UUID=3ba76f19-ce89-4f33-a818-2d5e34678830\s+/Lagoon2\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs1 entry added to fstab');
+
+set_desired_output('/sbin/blkid /dev/sdb3', 
+    '/dev/sdb3: UUID="f1b57f63-b545-44b5-b5c0-a24c578e0613" TYPE="ext3" PARTUUID="069218b3-02"');
+#use uuid f1b57f63-b545-44b5-b5c0-a24c578e0613
+$fs2->update_fstab;
+like(get_file('/etc/fstab'), qr{^UUID=f1b57f63-b545-44b5-b5c0-a24c578e0613\s+/Lagoon3\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs2 entry added to fstab');
+
+#use label
+$fs3->update_fstab;
+like(get_file('/etc/fstab'), qr{^LABEL=FSLAB\s+/Lagoon4\s+xfs\s+auto\s+0\s+1\s*[^/]*$}m, 'Mount fs3 entry added to fstab');
+
+# do it again! should still work
+my $newtxt = get_file('/etc/fstab'); #otherwise Can't coerce GLOB to string in substr 
+set_file("fstab_default","$newtxt");
+$fs0->update_fstab;
+$fs1->update_fstab;
+#Different UUID 7d03ea2f-8fa0-4cf6-ac30-4c98216420a0 than in file
+set_desired_output('/sbin/blkid /dev/sdb3', 
+    '/dev/sdb3: UUID="7d03ea2f-8fa0-4cf6-ac30-4c98216420a0" TYPE="ext3" PARTUUID="069218b3-02"');
+$fs2->update_fstab;
+$fs3->update_fstab;
+like(get_file('/etc/fstab'), qr{^/dev/sdb1\s+/Lagoon\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs0 entry added to fstab (retest)');
+like(get_file('/etc/fstab'), qr{^UUID=3ba76f19-ce89-4f33-a818-2d5e34678830\s+/Lagoon2\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs1 entry added to fstab (retest)');
+like(get_file('/etc/fstab'), qr{^UUID=7d03ea2f-8fa0-4cf6-ac30-4c98216420a0\s+/Lagoon3\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs2 entry added to fstab (retest)');
+like(get_file('/etc/fstab'), qr{^LABEL=FSLAB\s+/Lagoon4\s+xfs\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs3 entry added to fstab (retest)');
+
+
+$newtxt = get_file('/etc/fstab'); #otherwise Can't coerce GLOB to string in substr 
+set_file("fstab_default","$newtxt\n" . 'PARTUUID=069218b3-02   /Lagoon2   ext3  auto 0 1' );
+$fs1->update_fstab;
+like(get_file('/etc/fstab'), qr{^PARTUUID=069218b3-02\s+/Lagoon2\s+ext3\s+auto\s+0\s+1\s*[^/]*$}m, 
+    'Mount fs1 entry added to fstab with PARTUUID');
+
+done_testing();

--- a/src/test/perl/fstab.t
+++ b/src/test/perl/fstab.t
@@ -16,6 +16,7 @@ use helper;
 
 my $cfg = get_config_for_profile('fstab');
 
+$CAF::Object::NoAction = 1;
 # regular fs test
 my $fs0 = NCM::Filesystem->new ("/system/filesystems/0", $cfg);
 my $fs1 = NCM::Filesystem->new ("/system/filesystems/1", $cfg);

--- a/src/test/resources/fstab.pan
+++ b/src/test/resources/fstab.pan
@@ -20,6 +20,7 @@ include 'blockdevices';
     fs["block_device"] = "partitions/sdb4";
     fs["mountpoint"] = "/Lagoon4";
     fs["label"] = "FSLAB";
+    fs["type"] = "xfs";
     append(fs);
 
 };

--- a/src/test/resources/fstab.pan
+++ b/src/test/resources/fstab.pan
@@ -16,5 +16,11 @@ include 'blockdevices';
     fs["mountpoint"] = "/Lagoon3";
     append(fs);
 
+    fs=value("/system/filesystems/0");
+    fs["block_device"] = "partitions/sdb4";
+    fs["mountpoint"] = "/Lagoon4";
+    fs["label"] = "FSLAB";
+    append(fs);
+
 };
 


### PR DESCRIPTION
Adds support for keeping UUIDS in fstab. New entries also use the uuid when possible.
When given a hash of protected mointpoints or filesystems, these can be added,  but  not changed afterwards. 
For that feature to work, support has still to be added to ncm-fstab