### PR TITLE
Md: add support for named md devices, newer metadata, and parted in favour of fdisk

### DIFF
--- a/src/main/perl/MD.pm
+++ b/src/main/perl/MD.pm
@@ -203,7 +203,7 @@ Return the path in /dev/ of the MD device.
 sub devpath
 {
     my $self = shift;
-    return "/dev/$self->{devname}";
+    return "/dev/md/$self->{devname}";
 }
 
 =pod
@@ -313,19 +313,19 @@ EOC
             my $hdpath = $dev->{holding_dev}->devpath;
             my $hdname = $dev->{holding_dev}->{devname};
             my $n = $dev->partition_number;
-            print <<EOF;
-    fdisk $hdpath <<end_of_fdisk
-t
-\$(if [ \$(grep -c $hdname /proc/partitions) -gt 2 ]
-   then
-       echo $n
-   else
-       echo
-   fi)
-fd
-w
-end_of_fdisk
-EOF
+#            print <<EOF;
+#    fdisk $hdpath <<end_of_fdisk
+#t
+#\$(if [ \$(grep -c $hdname /proc/partitions) -gt 2 ]
+#   then
+#       echo $n
+#   else
+#       echo
+#   fi)
+#fd
+#w
+#end_of_fdisk
+#EOF
 
         }
         push (@devnames, $dev->devpath);
@@ -333,7 +333,7 @@ EOF
     }
     my $ndev = scalar(@devnames);
     print <<EOC;
-    sleep 5; mdadm --create --run $path --level=$self->{raid_level} --metadata=0.90 \\
+    sleep 5; mdadm --create --run $path --level=$self->{raid_level} #--metadata=0.90 \\
         --chunk=$self->{stripe_size} --raid-devices=$ndev \\
          @devnames
     echo @{[$self->devpath]} >> @{[PART_FILE]}

--- a/src/main/perl/MD.pm
+++ b/src/main/perl/MD.pm
@@ -203,7 +203,7 @@ Return the path in /dev/ of the MD device.
 sub devpath
 {
     my $self = shift;
-    return "/dev/md/$self->{devname}";
+    return "/dev/$self->{devname}";
 }
 
 =pod
@@ -313,19 +313,9 @@ EOC
             my $hdpath = $dev->{holding_dev}->devpath;
             my $hdname = $dev->{holding_dev}->{devname};
             my $n = $dev->partition_number;
-#            print <<EOF;
-#    fdisk $hdpath <<end_of_fdisk
-#t
-#\$(if [ \$(grep -c $hdname /proc/partitions) -gt 2 ]
-#   then
-#       echo $n
-#   else
-#       echo
-#   fi)
-#fd
-#w
-#end_of_fdisk
-#EOF
+            print <<EOF;
+	    parted $hdpath -s -- $hdpath set $n raid on
+EOF
 
         }
         push (@devnames, $dev->devpath);
@@ -333,7 +323,7 @@ EOC
     }
     my $ndev = scalar(@devnames);
     print <<EOC;
-    sleep 5; mdadm --create --run $path --level=$self->{raid_level} #--metadata=0.90 \\
+    sleep 5; mdadm --create --run $path --level=$self->{raid_level} --metadata=0.90 \\
         --chunk=$self->{stripe_size} --raid-devices=$ndev \\
          @devnames
     echo @{[$self->devpath]} >> @{[PART_FILE]}

--- a/src/test/perl/cmddata.pm
+++ b/src/test/perl/cmddata.pm
@@ -508,3 +508,12 @@ Number  Start    End     Size    File system  Flags
  1      0.00MiB  100MiB  100MiB  ext3
 
 EOF
+
+
+$cmds{mdadm_query_ok}{cmd}="/sbin/mdadm -Q /dev/md0";
+$cmds{mdadm_query_ok}{out}="Device exists";
+$cmds{mdadm_query_ok}{ec}=0;
+
+$cmds{mdadm_query_nok}{cmd}="/sbin/mdadm -Q /dev/md0";
+$cmds{mdadm_query_nok}{err}="Device not found";
+$cmds{mdadm_query_nok}{ec}=1;

--- a/src/test/perl/raid-ks.t
+++ b/src/test/perl/raid-ks.t
@@ -1,0 +1,58 @@
+#!/usr/bin/perl 
+# -*- mode: cperl -*-
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
+use strict;
+use warnings;
+
+use EDG::WP4::CCM::Element qw(escape);
+use Test::More;
+use Test::Quattor qw(raid);
+use helper;
+
+use Test::Quattor::RegexpTest;
+use Cwd;
+use NCM::MD;
+
+#$CAF::Object::NoAction = 1;
+set_disks({sdb => 1});
+
+my $regexpdir= getcwd()."/src/test/resources/regexps";
+my $cfg = get_config_for_profile('raid');
+my $md = NCM::MD->new ("/system/blockdevices/md/md0", $cfg);
+is (ref ($md), "NCM::MD", "MD correctly instantiated");
+
+# test some ks functions, those just print to default FH
+my $fhmd = CAF::FileWriter->new("target/test/ksfs");
+
+my $origfh = select($fhmd);
+
+$md->create_ks;
+diag "$fhmd";
+
+Test::Quattor::RegexpTest->new(
+    regexp => "$regexpdir/raid_create_ks_1",
+    text => "$fhmd"
+)->test();
+
+$md = NCM::MD->new ("/system/blockdevices/md/". escape('md/myname'), $cfg);
+is (ref ($md), "NCM::MD", "MD correctly instantiated");
+
+# test some ks functions, those just print to default FH
+my $fhmd2 = CAF::FileWriter->new("target/test/ksfs2");
+select($fhmd2);
+$md->create_ks;
+diag "$fhmd2";
+
+Test::Quattor::RegexpTest->new(
+    regexp => "$regexpdir/raid_create_ks_2",
+    text => "$fhmd2"
+)->test();
+
+# restore FH for DESTROY
+select($origfh);
+
+done_testing();

--- a/src/test/perl/raid.t
+++ b/src/test/perl/raid.t
@@ -20,14 +20,14 @@ my $cfg = get_config_for_profile('raid');
 my $md = NCM::MD->new ("/system/blockdevices/md/md0", $cfg);
 is (ref ($md), "NCM::MD", "MD correctly instantiated");
 
-# test mdstat parsing
-set_file('proc_mdstat_no_md0');
-is($md->devexists, '', 'No md0 entry in mdstat');
-set_file('proc_mdstat_md0');
-is($md->devexists, 1, 'Found md0 entry in mdstat');
+# test devexists 
+set_output('mdadm_query_ok');
+ok($md->devexists, 'Device exists');
+set_output('mdadm_query_nok');
+ok(!$md->devexists, 'No existing device');
 
 # doesn't exist yet
-set_file('proc_mdstat_no_md0');
+set_output('mdadm_query_nok');
 
 set_output("file_s_sdb_data"); # sdb exists (test via file -s)
 set_output("parted_print_sdb_2prim_gpt"); # sdb has 2 partitions

--- a/src/test/resources/blockdevices.pan
+++ b/src/test/resources/blockdevices.pan
@@ -44,7 +44,13 @@ unique template blockdevices;
 			"device_list", list ("partitions/sdb1", "partitions/sdb2"),
 			"raid_level", "RAID0",
 			"stripe_size", 64,
-			)
+			),
+        escape("md/myname"), nlist (
+            "device_list", list ("partitions/sdb3", "partitions/sdb4"),
+            "raid_level", "RAID0",
+            "stripe_size", 64,
+            "metadata", "1.2",
+            ),
 		),
 	"files", nlist (
 		escape ("/home/mejias/kk.ext3"), nlist (

--- a/src/test/resources/regexps/raid_create_ks_1
+++ b/src/test/resources/regexps/raid_create_ks_1
@@ -4,11 +4,11 @@ raid_create_ks_1
 ^if  ! grep -q md0 /proc/mdstat$
 ^then$
 ^/sbin/parted -s -- /dev/sdb set 1 raid on$
-^sed -i '\:/dev/sdb1\$:d' /tmp/created_partitions$
+^sed -i '\\:/dev/sdb1\$:d' /tmp/created_partitions$
 ^/sbin/parted -s -- /dev/sdb set 2 raid on$
-^sed -i '\:/dev/sdb2\$:d' /tmp/created_partitions$
-^\s{4}sleep 5; mdadm --create --run /dev/md0 --level=0 --metadata=0.90 \$
-^\s{8}--chunk=64 --raid-devices=2 \$
+^sed -i '\\:/dev/sdb2\$:d' /tmp/created_partitions$
+^\s{4}sleep 5; mdadm --create --run /dev/md0 --level=0 --metadata=0.90 \\$
+^\s{8}--chunk=64 --raid-devices=2 \\$
 ^\s{8} /dev/sdb1 /dev/sdb2$
 ^\s{4}echo /dev/md0 >> /tmp/created_partitions$
 ^fi$

--- a/src/test/resources/regexps/raid_create_ks_1
+++ b/src/test/resources/regexps/raid_create_ks_1
@@ -1,0 +1,14 @@
+raid_create_ks_1
+---
+---
+^if  ! grep -q md0 /proc/mdstat$
+^then$
+^/sbin/parted -s -- /dev/sdb set 1 raid on$
+^sed -i '\:/dev/sdb1\$:d' /tmp/created_partitions$
+^/sbin/parted -s -- /dev/sdb set 2 raid on$
+^sed -i '\:/dev/sdb2\$:d' /tmp/created_partitions$
+^\s{4}sleep 5; mdadm --create --run /dev/md0 --level=0 --metadata=0.90 \$
+^\s{8}--chunk=64 --raid-devices=2 \$
+^\s{8} /dev/sdb1 /dev/sdb2$
+^\s{4}echo /dev/md0 >> /tmp/created_partitions$
+^fi$

--- a/src/test/resources/regexps/raid_create_ks_2
+++ b/src/test/resources/regexps/raid_create_ks_2
@@ -4,11 +4,11 @@ raid_create_ks_2
 ^if  ! grep -q md/myname /proc/mdstat$
 ^then$
 ^/sbin/parted -s -- /dev/sdb set 3 raid on$
-^sed -i '\:/dev/sdb3\$:d' /tmp/created_partitions$
+^sed -i '\\:/dev/sdb3\$:d' /tmp/created_partitions$
 ^/sbin/parted -s -- /dev/sdb set 4 raid on$
-^sed -i '\:/dev/sdb4\$:d' /tmp/created_partitions$
-^\s{4}sleep 5; mdadm --create --run /dev/md/myname --level=0 --metadata=1.2 \$
-^\s{8}--chunk=64 --raid-devices=2 \$
+^sed -i '\\:/dev/sdb4\$:d' /tmp/created_partitions$
+^\s{4}sleep 5; mdadm --create --run /dev/md/myname --level=0 --metadata=1.2 \\$
+^\s{8}--chunk=64 --raid-devices=2 \\$
 ^\s{8} /dev/sdb3 /dev/sdb4$
 ^\s{4}echo /dev/md/myname >> /tmp/created_partitions$
 ^fi$

--- a/src/test/resources/regexps/raid_create_ks_2
+++ b/src/test/resources/regexps/raid_create_ks_2
@@ -1,0 +1,14 @@
+raid_create_ks_2
+---
+---
+^if  ! grep -q md/myname /proc/mdstat$
+^then$
+^/sbin/parted -s -- /dev/sdb set 3 raid on$
+^sed -i '\:/dev/sdb3\$:d' /tmp/created_partitions$
+^/sbin/parted -s -- /dev/sdb set 4 raid on$
+^sed -i '\:/dev/sdb4\$:d' /tmp/created_partitions$
+^\s{4}sleep 5; mdadm --create --run /dev/md/myname --level=0 --metadata=1.2 \$
+^\s{8}--chunk=64 --raid-devices=2 \$
+^\s{8} /dev/sdb3 /dev/sdb4$
+^\s{4}echo /dev/md/myname >> /tmp/created_partitions$
+^fi$


### PR DESCRIPTION
Comes together with https://github.com/quattor/template-library-core/pull/80, so the metadata param is configurable
Now parted is used instead of fdisk, and named md devices are supported
Fixes #55 and #54 