### PR TITLE
Make it possible to pass a logger to NCM::Blockdevices

### DIFF
--- a/src/main/perl/BlockdevFactory.pm
+++ b/src/main/perl/BlockdevFactory.pm
@@ -12,7 +12,7 @@ use warnings;
 use EDG::WP4::CCM::Configuration;
 use EDG::WP4::CCM::Element;
 use CAF::Process;
-use NCM::Blockdevices qw ($this_app);
+use NCM::Blockdevices qw ($reporter);
 use NCM::MD;
 use NCM::LVM;
 use NCM::LV;
@@ -67,7 +67,7 @@ sub build
         return NCM::VXVM->new(BASEPATH . $dev, $config);
     }
 
-    $this_app->error("Unable to find block device implementation for device $dev");
+    $self->error("Unable to find block device implementation for device $dev");
 
     return undef;
 }
@@ -76,7 +76,7 @@ sub build_from_dev
 {
     my ($dev, $config) = @_;
 
-    $this_app->debug (5, "Creating block device structure for $dev device");
+    $self->debug (5, "Creating block device structure for $dev device");
     if ($dev =~ m{^/dev/md\d+$}) {
         return NCM::MD->new_from_system ($dev, $config);
     }
@@ -90,7 +90,7 @@ sub build_from_dev
         # whether a path refers to a full disk or to a
         # partition.
         # TODO why output and not execute?
-        CAF::Process->new([PARTED, $dev, PARTEDEXTRA, PARTEDP], log => $this_app)->output();
+        CAF::Process->new([PARTED, $dev, PARTEDEXTRA, PARTEDP], log => $self)->output();
         if ($?) {
             return NCM::Disk->new_from_system ($dev, $config);
         }

--- a/src/main/perl/Blockdevices.pm
+++ b/src/main/perl/Blockdevices.pm
@@ -39,8 +39,8 @@ sub get_cache_key {
 
 sub _initialize
 {
-    my $self = shift;
-    $self->{log} = $reporter;
+    my ($self, %opts) = @_;
+    $self->{log} = $opts{log} || $reporter;
 	return $_[0];
 }
 

--- a/src/main/perl/Blockdevices.pm
+++ b/src/main/perl/Blockdevices.pm
@@ -39,7 +39,7 @@ sub get_cache_key {
 
 sub _initialize
 {
-    $self = shift;
+    my $self = shift;
     $self->{log} = $reporter;
 	return $_[0];
 }

--- a/src/main/perl/Blockdevices.pm
+++ b/src/main/perl/Blockdevices.pm
@@ -26,9 +26,9 @@ use constant GET_SIZE_BYTES  => qw (/sbin/blockdev --getsize64);
 
 our @ISA = qw/CAF::Object Exporter/;
 
-our $this_app = $main::this_app;
+our $reporter = $main::this_app;
 
-our @EXPORT_OK = qw ($this_app PART_FILE);
+our @EXPORT_OK = qw ($reporter PART_FILE);
 
 sub get_cache_key {
      my ($self, $path, $config) = @_;
@@ -39,6 +39,8 @@ sub get_cache_key {
 
 sub _initialize
 {
+    $self = shift;
+    $self->{log} = $reporter;
 	return $_[0];
 }
 
@@ -56,53 +58,53 @@ sub _set_alignment
 sub create
 {
 	my $self = shift;
-	$this_app->error ("create method not defined for this class");
+	$self->error ("create method not defined for this class");
 }
 
 sub remove
 {
 	my $self = shift;
-	$this_app->error ("remove method not defined for this class");
+	$self->error ("remove method not defined for this class");
 
 }
 
 sub grow
 {
 	my $self = shift;
-	$this_app->error ("grow method not defined for this class");
+	$self->error ("grow method not defined for this class");
 
 }
 
 sub shrink
 {
 	my $self = shift;
-	$this_app->error ("shrink method not defined for this class");
+	$self->error ("shrink method not defined for this class");
 
 }
 
 sub decide
 {
 	my $self = shift;
-	$this_app->error ("decide method not defined for this class");
+	$self->error ("decide method not defined for this class");
 }
 
 sub devexists
 {
 	my $self = shift;
-	$this_app->error ("devexists method not defined for this class");
+	$self->error ("devexists method not defined for this class");
 }
 
 
 sub should_print_ks
 {
 	my $self = shift;
-	$this_app->error ("should_print_ks method not defined for this class");
+	$self->error ("should_print_ks method not defined for this class");
 }
 
 sub should_create_ks
 {
 	my $self = shift;
-	$this_app->error ("should_create_ks method not defined for this class");
+	$self->error ("should_create_ks method not defined for this class");
 }
 
 # Return the size of metadata to wipe in MB
@@ -134,7 +136,7 @@ sub is_correct_device
 {
     my $self = shift;
     # Legacy behaviour is no checking; always assuming correct device.
-    $this_app->verbose ("is_correct_device method not defined. Returning true for legacy behaviour.");
+    $self->verbose ("is_correct_device method not defined. Returning true for legacy behaviour.");
     return 1;
 }
 
@@ -143,7 +145,7 @@ sub is_correct_device
 sub _size_in_byte
 {
     my $self = shift;
-    my $size = CAF::Process->new([GET_SIZE_BYTES, $self->devpath], log => $this_app)->output();
+    my $size = CAF::Process->new([GET_SIZE_BYTES, $self->devpath], log => $self)->output();
     chomp($size);
     return $size;
 }
@@ -164,9 +166,9 @@ sub size
     if ($self->devexists) {
         my $bytes = $self->_size_in_byte();
         $size = $bytes / (1024 * 1024);
-        $this_app->verbose("Device $self->{devname}, has size $size MiB ($bytes byte)");
+        $self->verbose("Device $self->{devname}, has size $size MiB ($bytes byte)");
     } else {
-        $this_app->verbose("No size for device $self->{devname}, devpath ",
+        $self->verbose("No size for device $self->{devname}, devpath ",
                            $self->devpath, " doesn't exist");
     }
     return $size;
@@ -201,7 +203,7 @@ sub correct_size_interval
     my $self = shift;
 
     my @conds = sort keys %{$self->{correct}->{size}};
-    $this_app->verbose("Going to use ", scalar @conds, " conditions: ", join(", ", @conds));    
+    $self->verbose("Going to use ", scalar @conds, " conditions: ", join(", ", @conds));    
 
     my ($min, $max);
 
@@ -224,25 +226,25 @@ sub correct_size_interval
         if ($cond eq "diff") {
             my $diff =  $self->{correct}->{size}->{diff};
             $update_min_max->($self->{size} - $diff, $self->{size} + $diff);
-            $this_app->verbose("Diff defined $diff, updated min/max $min / $max");
+            $self->verbose("Diff defined $diff, updated min/max $min / $max");
         } elsif ($cond eq "fraction") {
             my $frac = $self->{correct}->{size}->{fraction};
             $update_min_max->((1-$frac) * $self->{size}, (1+$frac) * $self->{size});
-            $this_app->verbose("Fraction defined $frac, updated min/max $min / $max");
+            $self->verbose("Fraction defined $frac, updated min/max $min / $max");
         } else {
-            $this_app->error("is_correct_size unknown condition $cond");
+            $self->error("is_correct_size unknown condition $cond");
             return;
         }
     };
 
 
     if(!defined($min)) {
-        $this_app->info("Minimum undefined after the conditions, using expected size $self->{size}");
+        $self->info("Minimum undefined after the conditions, using expected size $self->{size}");
         $min = $self->{size};
     }
     
     if(!defined($max)) {
-        $this_app->info("Maximum undefined after the conditions, using expected size $self->{size}");
+        $self->info("Maximum undefined after the conditions, using expected size $self->{size}");
         $max = $self->{size};
     }
 
@@ -250,7 +252,7 @@ sub correct_size_interval
     $max = 0 if ($max < 0);
 
     if($min > $max) {
-        $this_app->error("is_correct_size minimum $min larger then maximum $max");
+        $self->error("is_correct_size minimum $min larger then maximum $max");
         return;
     }
 
@@ -277,13 +279,13 @@ sub is_correct_size
     my $self = shift;
     
     if(! defined($self->{size})) {
-        $this_app->error("Attribute 'size' not found in profile");
+        $self->error("Attribute 'size' not found in profile");
         # considered failed. don't specify "correct/size" if you don't want this to run?
         return 0;
     }
 
     if(! $self->{correct}->{size}) {
-        $this_app->error("Sub-path 'correct/size' not found in profile");
+        $self->error("Sub-path 'correct/size' not found in profile");
         # considered failed. the code calling this method should check the existance 
         return 0;
     }
@@ -294,10 +296,10 @@ sub is_correct_size
 
     if($self->{size} == 0) {
         if ($self->{size} == $size) {
-            $this_app->verbose("expected size 0 matches found size");
+            $self->verbose("expected size 0 matches found size");
             return 1;
         } else {            
-            $this_app->error("expected size 0 not supported");
+            $self->error("expected size 0 not supported");
             # considered failed. don't specify "correct/size" if you don't want this to run?
             return 0;
         }
@@ -305,14 +307,14 @@ sub is_correct_size
     
     my $diff = abs($self->{size} - $size);
     my $msg = "found size $size MiB and expected size $self->{size} MiB";
-    $this_app->verbose("Size difference of $diff MiB between $msg");    
+    $self->verbose("Size difference of $diff MiB between $msg");    
 
     my ($min, $max) = $self->correct_size_interval();
 
     if($size >= $min && $size <= $max) {
-        $this_app->verbose("Found size $size in allowed interval [$min,$max] MiB");
+        $self->verbose("Found size $size in allowed interval [$min,$max] MiB");
     } else {
-        $this_app->error("Found size $size outside allowed interval [$min,$max] MiB");
+        $self->error("Found size $size outside allowed interval [$min,$max] MiB");
         return 0;
     }
     return 1;
@@ -330,7 +332,7 @@ the device is the correct device or not.
 sub ks_is_correct_device
 {
     my $self = shift;
-    $this_app->verbose ("ks_is_correct_device method not defined. Not printing anything for legacy behaviour.");
+    $self->verbose ("ks_is_correct_device method not defined. Not printing anything for legacy behaviour.");
     return 1;
 }
 
@@ -348,19 +350,19 @@ sub ks_pre_is_correct_size
     my $self = shift;
     
     if(! defined($self->{size})) {
-        $this_app->error("Attribute 'size' not found in profile");
+        $self->error("Attribute 'size' not found in profile");
         # considered failed. don't specify "correct/size" if you don't want this to run?
         return;
     }
 
     if(! $self->{correct}->{size}) {
-        $this_app->error("Sub-path 'correct/size' not found in profile");
+        $self->error("Sub-path 'correct/size' not found in profile");
         # considered failed. the code calling this method should check the existance 
         return;
     }
 
     if($self->{size} == 0) {
-        $this_app->error("Expected size 0 not supported in kickstart");
+        $self->error("Expected size 0 not supported in kickstart");
         # considered failed. don't specify "correct/size" if you don't want this to run?
         return;
     }
@@ -414,7 +416,7 @@ sub ksfsformat
                 push(@format, "--fsoptions='$fs->{mountopts}'");
             }
             if (exists($fs->{mkfsopts})) {
-                $this_app->warn("mkfsopts $fs->{mkfsopts} set for mountpoint $fs->{mountpoint}",
+                $self->warn("mkfsopts $fs->{mkfsopts} set for mountpoint $fs->{mountpoint}",
                                 "This is not supported in ksfsformat and ignored here");
             }            
     } else {
@@ -462,7 +464,7 @@ sub has_filesystem
         # a supported fs?                                                                                                                                                                
         # case sensitive, should be enforced via schema
         if ($fs !~ m{^$all_fs_regex$}) {
-            $this_app->warn("Requested filesystem $fs is not supported.",
+            $self->warn("Requested filesystem $fs is not supported.",
                             " Fallback to default supported filesystems.");
         } else {
             $fsregex = $fs;
@@ -470,9 +472,9 @@ sub has_filesystem
     };
 
     my $p = abs_path($self->devpath);
-    my $f =  CAF::Process->new([FILES, $p], log => $this_app)->output();
+    my $f =  CAF::Process->new([FILES, $p], log => $self)->output();
 
-    $this_app->debug(4, "Checking for filesystem on device $p",
+    $self->debug(4, "Checking for filesystem on device $p",
                         " with regexp '$fsregex' in output $f.");
     
     # case insensitive match 
@@ -494,14 +496,14 @@ sub get_uuid
     my ($self, $part) = @_;
     my $device = $self->devpath; 
     my $uuid;
-    my $output = CAF::Process->new([BLKID, $device], log => $this_app)->output();
+    my $output = CAF::Process->new([BLKID, $device], log => $self)->output();
     $part = $part ? 'PART' : '';
     my $re = qr!\s${part}UUID="(\S+)"!m ;
     if($output && $output =~ m/$re/m){
         $uuid = $1;
     }
     if (!defined($uuid)){
-        $this_app->warn("${part}UUID of device $device could not be found");
+        $self->warn("${part}UUID of device $device could not be found");
     }
     return $uuid;
 }

--- a/src/main/perl/Disk.pm
+++ b/src/main/perl/Disk.pm
@@ -108,9 +108,9 @@ Where the object creation is actually done.
 
 sub _initialize
 {
-    my ($self, $path, $config) = @_;
+    my ($self, $path, $config, %opts) = @_;
 
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
 
     my $st = $config->getElement($path)->getTree;
     $path =~ m(.*/([^/]+));

--- a/src/main/perl/Disk.pm
+++ b/src/main/perl/Disk.pm
@@ -157,17 +157,19 @@ sub _initialize
 
 sub new_from_system
 {
-    my ($class, $dev, $cfg) = @_;
+    my ($class, $dev, $cfg, %opts) = @_;
 
     my ($devname) = $dev =~ m{/dev/(.*)};
 
     my $cache_key = $class->get_cache_key("/system/blockdevices/physical_devs/" . $devname, $cfg);
     return $disks{$cache_key} if exists $disks{$cache_key};
 
-    my $self = {devname    => $devname,
-                label            => 'none',
-                _cache_key    => $cache_key
-                };
+    my $self = {
+        devname => $devname,
+        label => 'none',
+        _cache_key => $cache_key,
+        log => ($opts{log} || $reporter),
+    };
     return bless ($self, $class);
 }
 

--- a/src/main/perl/Disk.pm
+++ b/src/main/perl/Disk.pm
@@ -34,7 +34,7 @@ package NCM::Disk;
 
 use strict;
 use warnings;
-use NCM::Blockdevices qw ($this_app);
+use NCM::Blockdevices qw ($reporter);
 use CAF::Process;
 use CAF::FileEditor;
 use EDG::WP4::CCM::Element qw (unescape);
@@ -109,6 +109,9 @@ Where the object creation is actually done.
 sub _initialize
 {
     my ($self, $path, $config) = @_;
+
+    $self->{log} = $reporter;
+
     my $st = $config->getElement($path)->getTree;
     $path =~ m(.*/([^/]+));
 
@@ -122,7 +125,7 @@ sub _initialize
     # It is a bug in the templates if this happens
     my $host = $config->getElement (HOSTNAME)->getValue;
     my $domain = $config->getElement (DOMAINNAME)->getValue;
-    $this_app->error("Host $host.$domain: disk $self->{devname} is not defined under " . HWPATH) unless $hw;
+    $self->error("Host $host.$domain: disk $self->{devname} is not defined under " . HWPATH) unless $hw;
 
     if (exists $st->{size} ) {
         $self->{size} = $st->{size} ;
@@ -177,7 +180,7 @@ sub partitions_in_disk
     local $ENV{LANG} = 'C';
 
     my $line =  CAF::Process->new([PARTED, $self->devpath, PARTEDEXTRA, PARTEDP], 
-                                  log => $this_app)->output();
+                                  log => $self)->output();
 
     my @n = $line=~m/^\s*\d\s/mg;
     unless ($line =~ m/^(?:Disk label type|Partition Table): (\w+)/m) {
@@ -196,7 +199,7 @@ sub set_readahead
     my $re = join (" ", SETRA) . ".*", $self->devpath;
     my $okcmd = join (" ", SETRA, $self->{readahead}, $self->devpath);
     
-    my $fh = CAF::FileEditor->open (RCLOCAL, log => $this_app);
+    my $fh = CAF::FileEditor->open (RCLOCAL, log => $self);
                                             
     $fh->add_or_replace_lines ($re,
                                $okcmd,
@@ -240,16 +243,16 @@ sub create
         $self->remove;
 
         if ($self->{label} ne NOPART) {
-            $this_app->debug (5, "Initialising block device ",$self->devpath);
+            $self->debug (5, "Initialising block device ",$self->devpath);
             CAF::Process->new([PARTED, $self->devpath,
                                CREATE, $self->{label}],
-                              log => $this_app)->execute();
+                              log => $self)->execute();
             sleep (SLEEPTIME);
         }
         else {
-            $this_app->debug (5, "Disk ", $self->devpath,": create (zeroing partition table)");
-            my $buffout = CAF::Process->new([DD, DDARGS, "of=".$self->devpath], log => $this_app)->output();
-            $this_app->debug (5, "dd output:\n", $buffout);
+            $self->debug (5, "Disk ", $self->devpath,": create (zeroing partition table)");
+            my $buffout = CAF::Process->new([DD, DDARGS, "of=".$self->devpath], log => $self)->output();
+            $self->debug (5, "dd output:\n", $buffout);
         }
         return $?;
     }
@@ -274,9 +277,9 @@ sub remove
     return 1 if (! $self->is_correct_device);
 
     unless ($self->partitions_in_disk) {
-        $this_app->debug (5, "Disk ", $self->devpath,": remove (zeroing partition table)");
-        my $buffout = CAF::Process->new([DD, DDARGS, "of=".$self->devpath], log => $this_app)->output();
-        $this_app->debug (5, "dd output:\n", $buffout);
+        $self->debug (5, "Disk ", $self->devpath,": remove (zeroing partition table)");
+        my $buffout = CAF::Process->new([DD, DDARGS, "of=".$self->devpath], log => $self)->output();
+        $self->debug (5, "dd output:\n", $buffout);
     }
     return 0;
 }
@@ -300,7 +303,7 @@ sub is_correct_device
     my $self = shift;
     
     if (!$self->devexists) {
-        $this_app->error("is_correct_size no disk found for $self->{devname}.");
+        $self->error("is_correct_size no disk found for $self->{devname}.");
         return 0;
     }
     
@@ -309,7 +312,7 @@ sub is_correct_device
         if (! $correct_size) {
             # undef here due to e.g. missing size, non-existing device,...
             # is treated as failure
-            $this_app->error("is_correct_size failed for $self->{devname}");
+            $self->error("is_correct_size failed for $self->{devname}");
             return 0;
         };
     }

--- a/src/main/perl/File.pm
+++ b/src/main/perl/File.pm
@@ -22,7 +22,7 @@ use warnings;
 use EDG::WP4::CCM::Element qw (unescape);
 use EDG::WP4::CCM::Configuration;
 use LC::Process qw (execute output);
-use NCM::Blockdevices qw ($this_app);
+use NCM::Blockdevices qw ($reporter);
 our @ISA = qw (NCM::Blockdevices);
 
 use constant BASEPATH	=> "/system/blockdevices/";
@@ -35,6 +35,7 @@ sub _initialize
 {
     my ($self, $path, $config) = @_;
 
+    $self->{log} = $reporter;
     my $st = $config->getElement($path)->getTree;
 
     $path =~ m!/([^/]+)$!;
@@ -71,7 +72,7 @@ sub create
 
 	execute ([DD, SIZE.$self->{size}, OUT.$self->devpath]);
 	if ($?) {
-		$this_app->error ("Couldn't create file: ", $self->devpath);
+		$self->error ("Couldn't create file: ", $self->devpath);
 	} else {
 		chmod ($self->{permissions}, $self->devpath);
 		chown ($self->{owner}, $self->{group}, $self->devpath);

--- a/src/main/perl/File.pm
+++ b/src/main/perl/File.pm
@@ -144,9 +144,12 @@ sub devpath
 
 sub new_from_system
 {
-	my ($class, $dev, $cfg) = @_;
+	my ($class, $dev, $cfg, %opts) = @_;
 
-	my $self = { devname => $dev };
+	my $self = { 
+        devname => $dev, 
+        log => ($opts{log} || $reporter),
+};
 	return bless ($self, $class);
 }
 

--- a/src/main/perl/File.pm
+++ b/src/main/perl/File.pm
@@ -33,9 +33,9 @@ use constant OUT	=> 'of=';
 
 sub _initialize
 {
-    my ($self, $path, $config) = @_;
+    my ($self, $path, $config, %opts) = @_;
 
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
     my $st = $config->getElement($path)->getTree;
 
     $path =~ m!/([^/]+)$!;
@@ -149,7 +149,7 @@ sub new_from_system
 	my $self = { 
         devname => $dev, 
         log => ($opts{log} || $reporter),
-};
+    };
 	return bless ($self, $class);
 }
 

--- a/src/main/perl/Filesystem.pm
+++ b/src/main/perl/Filesystem.pm
@@ -14,7 +14,7 @@ use EDG::WP4::CCM::Configuration;
 use CAF::Process;
 use CAF::FileEditor;
 use CAF::FileReader;
-use NCM::Blockdevices qw ($this_app PART_FILE);
+use NCM::Blockdevices qw ($reporter PART_FILE);
 use NCM::BlockdevFactory qw (build build_from_dev);
 use FileHandle;
 use File::Basename;
@@ -76,10 +76,10 @@ sub new_from_fstab
     $line =~ m{^(\S+)\s+(\S+)\s};
     my ($dev, $mountp) = ($1, $2);
     my $p = CAF::Process->new ([MOUNT, $mountp],
-                               log => $this_app)->run();
+                               log => $self)->run();
 
     if ($dev =~ m/^(LABEL|UUID)=/) {
-        my $fh = CAF::FileReader->new(MTAB, log => $this_app);
+        my $fh = CAF::FileReader->new(MTAB, log => $self);
         my @mtd = grep (m{^\S+\s+$mountp/?\s}, split("\n", "$fh"));
         $fh->close();
         $dev = $mtd[0];
@@ -97,6 +97,8 @@ sub new_from_fstab
 sub _initialize
 {
     my ($self, $path, $config) = @_;
+        
+    $self->{log} = $reporter;
     my $st = $config->getElement($path)->getTree;
 
     while (my ($key, $val) = each (%$st)) {
@@ -118,7 +120,7 @@ Returns whether the filesystem is mounted
 sub mounted
 {
     my $self = shift;
-    my $fh = CAF::FileReader->new(MTAB, log => $this_app);
+    my $fh = CAF::FileReader->new(MTAB, log => $self);
     return $fh =~ m!^\S+\s+$self->{mountpoint}/?\s!m;
 }
 
@@ -136,21 +138,21 @@ sub remove_if_needed
     my $self = shift;
 
     if ($self->{preserve} || !$self->{format}) {
-        $this_app->debug (5, "Filesystem ", $self->{mountpoint},
+        $self->debug (5, "Filesystem ", $self->{mountpoint},
               " shouldn't be destroyed according to profile.");
         return 0;
     }
-    $this_app->info ("Destroying filesystem on $self->{mountpoint}");
+    $self->info ("Destroying filesystem on $self->{mountpoint}");
     if ($self->mounted) {
         CAF::Process->new ([UMOUNT, $self->{mountpoint}],
-                  log => $this_app)->run();
+                  log => $self)->run();
         return $? if $?;
     }
     $self->{block_device}->remove==0 or return $?;
-    my $fh = CAF::FileEditor->new (FSTAB, log => $this_app);
+    my $fh = CAF::FileEditor->new (FSTAB, log => $self);
     $fh->remove_lines(qr/\s$self->{mountpoint}\s/, qr/^$/); # goodre ^$ (empty string) should never match  
     $fh->close();
-    $this_app->debug (5, "Removing filesystem mountpoint", $self->{mountpoint});
+    $self->debug (5, "Removing filesystem mountpoint", $self->{mountpoint});
     rmdir ($self->{mountpoint});
     return $?;
 }
@@ -183,11 +185,11 @@ sub check_in_fstab
             my ($type_uuid, $fstab_uuid) = ($1 || '' , $2);
             my $prof_uuid = $self->{block_device}->get_uuid($type_uuid);
             if (!$prof_uuid) {
-                $this_app->warn("${type_uuid}UUID of device $devpath for $self->{mountpoint} ", 
+                $self->warn("${type_uuid}UUID of device $devpath for $self->{mountpoint} ", 
                     "in profile could not be found");
                 next;
             } elsif ($prof_uuid ne $fstab_uuid) {
-                $this_app->warn("${type_uuid}UUID of device $devpath for $self->{mountpoint} ", 
+                $self->warn("${type_uuid}UUID of device $devpath for $self->{mountpoint} ", 
                     "in profile is different from that in the fstab file!");
             }
             $ndevice = "${type_uuid}UUID=$prof_uuid";
@@ -202,10 +204,10 @@ sub check_in_fstab
         }
     } else {
         if ($protected && $protected->{mounts}->{$self->{mountpoint}}){
-            $this_app->verbose("Mount $self->{mountpoint} is protected and will not be changed");
+            $self->verbose("Mount $self->{mountpoint} is protected and will not be changed");
             $ndevice = undef;
         } elsif ($protected && $protected->{fs_types}->{$otype}){
-            $this_app->verbose("Mount $self->{mountpoint} is of protected type $otype and will not be changed");
+            $self->verbose("Mount $self->{mountpoint} is of protected type $otype and will not be changed");
             $ndevice = undef;
         } elsif (exists $self->{label}) {
             $ndevice = "LABEL=$self->{label}"; # Always use label if in template
@@ -236,10 +238,10 @@ sub update_fstab
     if(ref($fh) eq 'CAF::FileEditor') {
         # TODO check if not closed?
         $close_fh = 0;
-        $this_app->debug(3, "A CAF::FileEditor instance was passed. ",
+        $self->debug(3, "A CAF::FileEditor instance was passed. ",
                            "It will not be closed at end of this method.");
     } else {
-        $fh = CAF::FileEditor->new (FSTAB, log => $this_app, backup => '.old');
+        $fh = CAF::FileEditor->new (FSTAB, log => $self, backup => '.old');
     };
 
     my $ok_device = $self->check_in_fstab($fh, $pstrict);
@@ -279,7 +281,7 @@ sub formatfs
     my $self = shift;
 
     if (! $self->{block_device}->is_correct_device) {
-        $this_app->error("Filesystem mountpoint $self->{mountpoint}",
+        $self->error("Filesystem mountpoint $self->{mountpoint}",
                           " not correct blockdev ", $self->{block_device}->devpath);
         $? = 1;
         return 1;
@@ -299,27 +301,27 @@ sub formatfs
     # the block device has a filesystem. Don't destroy the data.
     my $has_filesystem = 1;
     if ($self->{type} eq 'none') {
-        $this_app->debug(3, "type 'none', no format.");
+        $self->debug(3, "type 'none', no format.");
         $has_filesystem = 1;
     } elsif(defined($self->{force_filesystemtype}) && $self->{force_filesystemtype}) {
         $has_filesystem = $self->{block_device}->has_filesystem($self->{type});
-        $this_app->debug(3, "force_filesystemtype with type $self->{type}",
+        $self->debug(3, "force_filesystemtype with type $self->{type}",
                             " has_filesystem $has_filesystem");
     } else {
         $has_filesystem = $self->{block_device}->has_filesystem;
-        $this_app->debug(3, "any supported filesystem",
+        $self->debug(3, "any supported filesystem",
                             " has_filesystem $has_filesystem");
     };
     
     if (!$has_filesystem) {
-        $this_app->debug (5, "Formatting to get $self->{mountpoint}");
+        $self->debug (5, "Formatting to get $self->{mountpoint}");
         CAF::Process->new ([MKFSCMDS->{$self->{type}}, @opts,
                             $self->{block_device}->devpath],
-                            log => $this_app)->run();
+                            log => $self)->run();
         return $? if $?;
         CAF::Process->new ([$tunecmd, split ('\s+', $self->{tuneopts}),
                             $self->{block_device}->devpath],
-                            log => $this_app)->run()
+                            log => $self)->run()
                 if exists $self->{tuneopts} && defined $tunecmd;
     }
     return $?;
@@ -339,7 +341,7 @@ sub mkmountpoint
     my $mp = shift;
     eval { mkpath ([$mp], 0, MOUNTPOINTPERMS) };
     if ($@) {
-        $this_app->error ("Failed to create mount point $mp: $@");
+        $self->error ("Failed to create mount point $mp: $@");
         return -1;
     }
     return 0;
@@ -357,7 +359,7 @@ sub mountpoint_in_fstab
 {
     my $self = shift;
 
-    my $fh = CAF::FileReader->new(FSTAB, log => $this_app);
+    my $fh = CAF::FileReader->new(FSTAB, log => $self);
     return $fh =~ m!^\s*[^#]\S+\s+$self->{mountpoint}/?\s!m;
 }
 
@@ -388,7 +390,7 @@ sub is_create_needed
         $ret=0;
     }
 
-    $this_app->debug (5, "Filesystem mountpoint $self->{mountpoint}",
+    $self->debug (5, "Filesystem mountpoint $self->{mountpoint}",
                       " is_create_needed $ret: $msg");
     
     return $ret;
@@ -408,11 +410,11 @@ sub create_if_needed
 {
     my $self = shift;
 
-    $this_app->debug (5, "Filesystem mountpoint $self->{mountpoint}",
+    $self->debug (5, "Filesystem mountpoint $self->{mountpoint}",
                       " blockdev ", $self->{block_device}->devpath);
 
     if (! $self->{block_device}->is_correct_device) {
-        $this_app->error("Filesystem mountpoint $self->{mountpoint}",
+        $self->error("Filesystem mountpoint $self->{mountpoint}",
                           " not correct blockdev ", $self->{block_device}->devpath);
         $? = 1;
         return 1;
@@ -421,7 +423,7 @@ sub create_if_needed
     if($self->is_create_needed) {
         $self->{block_device}->create && return $?;
         $self->formatfs && return $?;
-        $this_app->info("Filesystem on $self->{mountpoint} successfully created");
+        $self->info("Filesystem on $self->{mountpoint} successfully created");
     };
     return 0;
 }
@@ -461,7 +463,7 @@ sub format_if_needed
     my ($self, %protected) = @_;
 
     if (! $self->{block_device}->is_correct_device) {
-        $this_app->error("Filesystem mountpoint $self->{mountpoint}",
+        $self->error("Filesystem mountpoint $self->{mountpoint}",
                           " not correct blockdev ", $self->{block_device}->devpath);
 		$? = 1;
         return 1;
@@ -469,9 +471,9 @@ sub format_if_needed
 
     $self->can_be_formatted(%protected) or return 0;
     my $r;
-    CAF::Process->new ([UMOUNT, $self->{mountpoint}], log => $this_app)->run();
+    CAF::Process->new ([UMOUNT, $self->{mountpoint}], log => $self)->run();
     $r = $self->formatfs;
-    CAF::Process->new ([MOUNT, $self->{mountpoint}], log => $this_app)->run()
+    CAF::Process->new ([MOUNT, $self->{mountpoint}], log => $self)->run()
         if $self->{mount};
     return $r;
 }

--- a/src/main/perl/Filesystem.pm
+++ b/src/main/perl/Filesystem.pm
@@ -100,16 +100,16 @@ sub new_from_fstab
 
 sub _initialize
 {
-    my ($self, $path, $config) = @_;
+    my ($self, $path, $config, %opts) = @_;
         
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
     my $st = $config->getElement($path)->getTree;
 
     while (my ($key, $val) = each (%$st)) {
         $self->{$key} = $val;
     }
 
-    $self->{block_device} = build ($config, $self->{block_device});
+    $self->{block_device} = build ($config, $self->{block_device}, %opts);
     return $self;
 }
 

--- a/src/main/perl/HWRaid.pm
+++ b/src/main/perl/HWRaid.pm
@@ -77,9 +77,9 @@ The disk object on top of this RAID array.
 
 sub _initialize
 {
-    my ($self, $path, $config, $parent) = @_;
+    my ($self, $path, $config, $parent, %opts) = @_;
 
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
 
     $path =~ m{^([^/]*)};
     $self->{unit} = $1;

--- a/src/main/perl/HWRaid.pm
+++ b/src/main/perl/HWRaid.pm
@@ -20,7 +20,7 @@ package NCM::HWRaid;
 
 use strict;
 use warnings;
-use NCM::Blockdevices qw ($this_app);
+use NCM::Blockdevices qw ($reporter);
 use EDG::WP4::CCM::Element;
 # TODO: convert all modules to use CAF::Process
 use CAF::Process;
@@ -79,13 +79,15 @@ sub _initialize
 {
     my ($self, $path, $config, $parent) = @_;
 
+    $self->{log} = $reporter;
+
     $path =~ m{^([^/]*)};
     $self->{unit} = $1;
     $self->{unit} =~ tr/_/u/;
     $path = RAIDPATH . $path;
 
     unless ($config->elementExists ($path)) {
-	$this_app->error ("RAID array on $path doesn't exist");
+	$self->error ("RAID array on $path doesn't exist");
 	return undef;
     }
 
@@ -96,7 +98,7 @@ sub _initialize
 
     foreach my $dev (@{$t->{device_list}}) {
 	unless ($dev =~ m{^raid/_\d+/ports/_(\d+).*}) {
-	    $this_app->error ("This device is not a RAID port, leaving");
+	    $self->error ("This device is not a RAID port, leaving");
 	    return undef;
 	}
 	push (@dl, $1);
@@ -110,7 +112,7 @@ sub _initialize
     $t->{device_list}->[0] =~ m{^raid/_(\d+)};
     $self->{controller} = "c$1";
     unless ($config->elementExists (HWPATH . "_$1" . VENDORSTRING)) {
-	$this_app->error ("No vendor defined for the RAID controller on ",
+	$self->error ("No vendor defined for the RAID controller on ",
 			  HWPATH, "_$1", VENDORSTRING,
 			  " Leaving");
 	return undef;
@@ -151,7 +153,7 @@ sub create
     my $self = shift;
 
     unless ($self->is_consistent) {
-	$this_app->error ("The RAID status and the profile are inconsistent. ",
+	$self->error ("The RAID status and the profile are inconsistent. ",
 			  "Fix your profile or manually adjust your RAID.");
 	return -1;
     }
@@ -182,7 +184,7 @@ sub is_consistent
     $self->debug (5, "Checking consistency for RAID on controller: ",
 		  "$self->{controller}, expected on device ",
 		  $self->{parent}->devpath);
-    my $proc = CAF::Process->new ([HWRAIDINFO], log => $this_app);
+    my $proc = CAF::Process->new ([HWRAIDINFO], log => $self);
 
     $raid_status = $proc->output;
     return 0 if $?;
@@ -195,12 +197,12 @@ sub is_consistent
     }
     if ($raid_status =~ m{^(.*$self->{parent}->{devname})}m) {
 	@fields = split (/,/, $1);
-	$this_app->error ("Wrong vendor specified for unit $self->{unit}")
+	$self->error ("Wrong vendor specified for unit $self->{unit}")
 	    if exists $self->{vendor} &&
 	      $fields[VENDOR] ne (lc $self->{vendor});
-	$this_app->error ("Wrong controller specified for unit $self->{unit}")
+	$self->error ("Wrong controller specified for unit $self->{unit}")
 	    if $fields[CONTROLLER] ne $self->{controller};
-	$this_app->error ("Disk ", $self->{parent}->devpath,
+	$self->error ("Disk ", $self->{parent}->devpath,
 			  " exists, but is associated to a different ",
 			  "RAID unit. Expected: $self->{unit}")
 	    if $fields[UNIT] ne $self->{unit};
@@ -210,7 +212,7 @@ sub is_consistent
 				   $self->{unit}.*)}xmi) {
 	@fields = split (/,/, $1);
 	if ($fields[OSDISK] ne NODISK) {
-	    $this_app->error ("The selected RAID array holds ",
+	    $self->error ("The selected RAID array holds ",
 			      "a different device: $fields[OSDISK]");
 	    return 0;
 	}
@@ -234,7 +236,7 @@ Returns 0 if succeeds, -1 in case of errors.
 sub destroy_if_needed
 {
     my $self = shift;
-    my $proc = CAF::Process->new ([HWRAIDINFO], log => $this_app);
+    my $proc = CAF::Process->new ([HWRAIDINFO], log => $self);
 
     my $raid_status = $proc->output;
     my @candidates = grep (m{$self->{controller}}, split (/\n/, $raid_status));
@@ -251,7 +253,7 @@ sub destroy_if_needed
 	    return $self->do_destroy ($l[0]);
 	}
     }
-    $this_app->debug (5, "Didn't have to destroy array $self->{unit}");
+    $self->debug (5, "Didn't have to destroy array $self->{unit}");
     return 0;
 }
 
@@ -265,8 +267,8 @@ will be fed, as is, to hwraidman.
 sub do_destroy
 {
     my ($self, $raidinfo) = @_;
-    $this_app->debug (5, "Must destroy array $self->{unit}");
-    my $proc = CAF::Process->new ([HWRAIDDESTROY], log => $this_app,
+    $self->debug (5, "Must destroy array $self->{unit}");
+    my $proc = CAF::Process->new ([HWRAIDDESTROY], log => $self,
 				  stdin => "$raidinfo\n");
     my $err = $proc->execute();
     return $?
@@ -284,11 +286,11 @@ Returns 0 if it succeeds, something different in case of errors.
 sub create_if_needed
 {
     my $self = shift;
-    my $proc = CAF::Process->new ([HWRAIDINFO], log => $this_app);
+    my $proc = CAF::Process->new ([HWRAIDINFO], log => $self);
     my $raid_status = $proc->output;
     my @raidline;
     return 0 if $raid_status =~ m{$self->{unit}};
-    $this_app->debug (5, "Array $self->{unit} doesn't exist. Creating it.");
+    $self->debug (5, "Array $self->{unit} doesn't exist. Creating it.");
     my $disklist = join (DISKSEP, "", @{$self->{device_list}});
     $raidline[VENDOR] = lc ($self->{vendor});
     $raidline[CONTROLLER] = $self->{controller};
@@ -300,7 +302,7 @@ sub create_if_needed
     $raidline[OSDISK] = $self->{parent}->{devname};
     $raidline[RAIDSTATUS] = EMPTY;
 
-    $proc = CAF::Process->new ([HWRAIDCREATE], log => $this_app,
+    $proc = CAF::Process->new ([HWRAIDCREATE], log => $self,
 			       stdin => join (JOINER, @raidline) . "\n");
     $proc->execute;
     return $?;

--- a/src/main/perl/LV.pm
+++ b/src/main/perl/LV.pm
@@ -112,15 +112,16 @@ rest of the class can understand.
 
 sub new_from_system
 {
-    my ($class, $dev, $cfg) = @_;
+    my ($class, $dev, $cfg, %opts) = @_;
 
     $dev =~ m{(/dev/.*[^-]+)-([^-].*)$};
     my ($vgname, $devname) = ($1, $2);
     $devname =~ s/-{2}/-/g;
-    my $vg = NCM::LVM->new_from_system($vgname, $cfg);
+    my $vg = NCM::LVM->new_from_system($vgname, $cfg, %opts);
     my $self = {
         devname      => $devname,
-        volume_group => $vg
+        volume_group => $vg,
+        log => ($opts{log} || $reporter),
     };
     return bless($self, $class);
 }

--- a/src/main/perl/LV.pm
+++ b/src/main/perl/LV.pm
@@ -61,9 +61,9 @@ Where the object creation is actually done.
 
 sub _initialize
 {
-    my ($self, $path, $config) = @_;
+    my ($self, $path, $config, %opts) = @_;
 
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
     my $st = $config->getElement($path)->getTree;
     $path =~ m!/([^/]+)$!;
     $self->{devname}      = $1;
@@ -79,7 +79,7 @@ sub _initialize
     if ($st->{devices}) {
         $self->{devices} = [];
         foreach my $devpath (@{$st->{devices}}) {
-            my $dev = NCM::BlockdevFactory::build($config, $devpath);
+            my $dev = NCM::BlockdevFactory::build($config, $devpath, %opts);
             if (!$dev){
                 $self->error("Something went wrong building device for $devpath");
                 return;

--- a/src/main/perl/LVM.pm
+++ b/src/main/perl/LVM.pm
@@ -194,9 +194,9 @@ Where the object creation is actually done
 
 sub _initialize
 {
-    my ($self, $path, $config) = @_;
+    my ($self, $path, $config, %opts) = @_;
 
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
     my $st = $config->getElement($path)->getTree;
     if ($config->elementExists(VOLGROUP_REQUIRED_PATH)) {
         $self->{_volgroup_required} = $config->getElement(VOLGROUP_REQUIRED_PATH)->getTree();
@@ -206,7 +206,7 @@ sub _initialize
     $path =~ m!/([^/]+)$!;
     $self->{devname} = $1;
     foreach my $devpath (@{$st->{device_list}}) {
-        my $dev = NCM::BlockdevFactory::build($config, $devpath);
+        my $dev = NCM::BlockdevFactory::build($config, $devpath, %opts);
         push(@{$self->{device_list}}, $dev);
     }
 

--- a/src/main/perl/LVM.pm
+++ b/src/main/perl/LVM.pm
@@ -164,7 +164,7 @@ sub remove
 
 sub new_from_system
 {
-    my ($class, $dev, $cfg) = @_;
+    my ($class, $dev, $cfg, %opts) = @_;
 
     $dev =~ m{dev/mapper/(.*)};
     my $devname = $1;
@@ -174,11 +174,12 @@ sub new_from_system
     my $pvs = output(PVS);
     my @pv;
     while ($pvs =~ m{^\s*(\S+)\s+$devname$}omgc) {
-        push(@pv, build_from_dev($1, $cfg));
+        push(@pv, build_from_dev($1, $cfg, %opts));
     }
     my $self = {
         devname     => $devname,
-        device_list => \@pv
+        device_list => \@pv,
+        log => ($opts{log} || $reporter),
     };
     return bless($self, $class);
 }

--- a/src/main/perl/LVM.pm
+++ b/src/main/perl/LVM.pm
@@ -40,7 +40,7 @@ use CAF::Process;
 use EDG::WP4::CCM::Element;
 use EDG::WP4::CCM::Configuration;
 use LC::Process qw(execute output);
-use NCM::Blockdevices qw($this_app PART_FILE);
+use NCM::Blockdevices qw ($reporter PART_FILE);
 use NCM::BlockdevFactory qw(build build_from_dev);
 our @ISA = qw(NCM::Blockdevices);
 
@@ -102,7 +102,7 @@ sub create
     return 1 if (!$self->is_correct_device);
 
     if ($self->devexists) {
-        $this_app->debug(5, "Volume group $self->{devname} already ", " exists. Leaving");
+        $self->debug(5, "Volume group $self->{devname} already ", " exists. Leaving");
         return 0;
     }
     foreach my $dev (@{$self->{device_list}}) {
@@ -113,7 +113,7 @@ sub create
         push(@devnames, $dev->devpath);
     }
     execute([VGCREATE, $self->{devname}, VGCOPTS, @devnames]);
-    $this_app->error("Failed to create volume group $self->{devname}")
+    $self->error("Failed to create volume group $self->{devname}")
         if $?;
     return $?;
 }
@@ -141,7 +141,7 @@ sub remove
     # Remove the VG only if it has no logical volumes left.
     my @n = split /:/, output((VGDISPLAY, $self->{devname}));
     if ($n[EXISTS]) {
-        $this_app->debug(
+        $self->debug(
             5, "Volume group $self->{devname} ",
             "has ", $n[EXISTS],
             " logical volumes left.",
@@ -155,7 +155,7 @@ sub remove
     }
     foreach my $dev (@{$self->{device_list}}) {
         execute([PVREMOVE, $dev->devpath]);
-        $this_app->error("Failed to remove labels on PV", $dev->devpath) if $?;
+        $self->error("Failed to remove labels on PV", $dev->devpath) if $?;
         $dev->remove == 0 or last;
     }
     delete $vgs{$self->{_cache_key}} if exists $self->{_cache_key};
@@ -194,6 +194,8 @@ Where the object creation is actually done
 sub _initialize
 {
     my ($self, $path, $config) = @_;
+
+    $self->{log} = $reporter;
     my $st = $config->getElement($path)->getTree;
     if ($config->elementExists(VOLGROUP_REQUIRED_PATH)) {
         $self->{_volgroup_required} = $config->getElement(VOLGROUP_REQUIRED_PATH)->getTree();
@@ -282,7 +284,7 @@ sub devexists
     # Ugly hack because SL's vgdisplay sucks: the volume exists if
     # vgdisplay has any output
     # -> Is this still valid? In >= sl6, exitcode can be used
-    my $output = CAF::Process->new([VGDISPLAY, $self->{devname}], log => $this_app)->output();
+    my $output = CAF::Process->new([VGDISPLAY, $self->{devname}], log => $self)->output();
     my @lines = split /:/, $output;
     return scalar(@lines) > 1;
 }

--- a/src/main/perl/MD.pm
+++ b/src/main/perl/MD.pm
@@ -58,7 +58,7 @@ sub _initialize
 {
     my ($self, $path, $config, %opts) = @_;
 
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
     my $st = $config->getElement($path)->getTree;
     $path=~m!/([^/]+)$!;
     $self->{devname} = unescape($1);
@@ -88,9 +88,9 @@ software RAID device.
 
 sub new
 {
-    my ($class, $path, $config) = @_;
+    my ($class, $path, $config, %opts) = @_;
     my $cache_key = $class->get_cache_key($path, $config);
-    return (exists $mds{$cache_key}) ? $mds{$cache_key} : $class->SUPER::new ($path, $config);
+    return (exists $mds{$cache_key}) ? $mds{$cache_key} : $class->SUPER::new ($path, $config, %opts);
 }
 
 =pod

--- a/src/main/perl/Partition.pm
+++ b/src/main/perl/Partition.pm
@@ -111,21 +111,22 @@ Creates a partition object from its path on the disk.
 
 sub new_from_system
 {
-    my ($class, $dev, $cfg) = @_;
+    my ($class, $dev, $cfg, %opts) = @_;
 
     $dev =~ m{/dev/(.*)};
     my $devname = $1;
     my $disk;
     if ($dev =~ m{(/dev/ciss/c\d+d\+)p\d+}) {
         $disk = $1;
-    }
-    else {
+    } else {
         $dev =~ m{(/dev/.*\D)\d+$};
         $disk = $1;
     }
-    my $self = {devname	=> $devname,
-                holding_dev	=> NCM::Disk->new_from_system ($disk, $cfg)
-                };
+    my $self = {
+        devname	=> $devname,
+        holding_dev	=> NCM::Disk->new_from_system ($disk, $cfg, %opts),
+        log => ($opts{log} || $reporter),
+    };
     return bless ($self, $class);
 }
 

--- a/src/main/perl/Partition.pm
+++ b/src/main/perl/Partition.pm
@@ -141,9 +141,9 @@ the profile for the device and the configuration object.
 
 sub _initialize
 {
-    my ($self, $path, $config) = @_;
+    my ($self, $path, $config, %opts) = @_;
 
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
     my $st = $config->getElement($path)->getTree;
     # The block device is indexed by disk name
     $path =~ m!([^/]+)$!;

--- a/src/main/perl/Tmpfs.pm
+++ b/src/main/perl/Tmpfs.pm
@@ -7,7 +7,7 @@ package NCM::Tmpfs;
 use strict;
 use warnings;
 
-use NCM::Blockdevices qw ($this_app);
+use NCM::Blockdevices qw ($reporter);
 
 our @ISA = qw{NCM::Blockdevices};
 
@@ -43,7 +43,7 @@ sub should_create_ks
 sub _size_in_byte
 {
     my $self = shift;
-    $this_app->error ("_size_in_byte method not defined for this class");
+    $self->error ("_size_in_byte method not defined for this class");
 }
 
 __END__

--- a/src/main/perl/VXVM.pm
+++ b/src/main/perl/VXVM.pm
@@ -40,6 +40,7 @@ sub _initialize
 
 sub create
 {
+    my $self = shift;
     $self->verbose("create not supported");
     return 0;
 }

--- a/src/main/perl/VXVM.pm
+++ b/src/main/perl/VXVM.pm
@@ -26,9 +26,9 @@ our $reporter = $main::this_app;
 
 sub _initialize
 {
-    my ($self, $path, $config) = @_;
+    my ($self, $path, $config, %opts) = @_;
 
-    $self->{log} = $reporter;
+    $self->{log} = $opts{log} || $reporter;
     if ($path =~ m!/([^/]+)$!) {
         $self->{devname} = unescape($1);
     } else {

--- a/src/main/perl/VXVM.pm
+++ b/src/main/perl/VXVM.pm
@@ -22,16 +22,17 @@ use EDG::WP4::CCM::Element qw (unescape);
 
 our @ISA = qw{NCM::Blockdevices};
 
-our $this_app = $main::this_app;
+our $reporter = $main::this_app;
 
 sub _initialize
 {
     my ($self, $path, $config) = @_;
 
+    $self->{log} = $reporter;
     if ($path =~ m!/([^/]+)$!) {
         $self->{devname} = unescape($1);
     } else {
-        $this_app->error("cannot determine devname from $path");
+        $self->error("cannot determine devname from $path");
     }
 
     return $self;
@@ -39,7 +40,7 @@ sub _initialize
 
 sub create
 {
-    $this_app->verbose("create not supported");
+    $self->verbose("create not supported");
     return 0;
 }
 

--- a/src/test/perl/factory.t
+++ b/src/test/perl/factory.t
@@ -37,6 +37,6 @@ is (ref ($o), "NCM::VXVM", "VXVM correctly instantiated");
 
 $o = build ($cfg, "unknown/unknown");
 ok(! defined($o), 'build returns undef with unknown blockdevice');
-is($self->{ERROR}, 1, "Errors for an unknown blockdevice");
+is($reporter->{ERROR}, 1, "Errors for an unknown blockdevice");
 
 done_testing();

--- a/src/test/perl/factory.t
+++ b/src/test/perl/factory.t
@@ -12,7 +12,7 @@ use Test::More;
 use Test::Quattor qw(factory);
 use helper;
 
-use NCM::Blockdevices qw ($this_app);
+use NCM::Blockdevices qw ($reporter);
 use NCM::BlockdevFactory qw (build);
 use CAF::Object;
 
@@ -37,6 +37,6 @@ is (ref ($o), "NCM::VXVM", "VXVM correctly instantiated");
 
 $o = build ($cfg, "unknown/unknown");
 ok(! defined($o), 'build returns undef with unknown blockdevice');
-is($this_app->{ERROR}, 1, "Errors for an unknown blockdevice");
+is($self->{ERROR}, 1, "Errors for an unknown blockdevice");
 
 done_testing();

--- a/src/test/perl/helper.pm
+++ b/src/test/perl/helper.pm
@@ -31,12 +31,12 @@ use Test::Quattor;
 use CAF::Object;
 $CAF::Object::NoAction = 1;
 
-# force this_app, so most log => $this_app works
+# force reporter, so most log => $self works
 # in particular, this is not mocked in FileWriter/FileEditor
 use NCM::Component;
 my $cmp=NCM::Component->new("dummy");
 use NCM::Blockdevices;
-$NCM::Blockdevices::this_app = $cmp;
+$NCM::Blockdevices::reporter = $cmp;
 
 use cmddata;
 sub set_output {


### PR DESCRIPTION
Replaces this_app, make it possible to pass the logger to the NCM objects from eg ncm-fstab and ncm-filesystems.

Fixes #53