### PR TITLE
Partition: export partition_sort instead of partition_compare

### DIFF
--- a/src/main/perl/Partition.pm
+++ b/src/main/perl/Partition.pm
@@ -54,7 +54,7 @@ use NCM::Disk;
 use CAF::Process;
 use parent qw(NCM::Blockdevices Exporter);
 
-our @EXPORT_OK = qw (partition_compare);
+our @EXPORT_OK = qw (partition_sort);
 
 use constant {
     PARTED		=> "/sbin/parted",
@@ -83,16 +83,35 @@ use constant BLOCKDEV	=> qw (/sbin/blockdev --rereadpt --);
 use constant PARTEDP	=> 'print';
 
 # Returns 1 if $a must be created before $b, -1 if $b must be created
-# before $a, 0 if it doesn't matter. See bug #26137.
+# before $a, 0 if it doesn't matter.
+# $a and $b are global package variables for sort
 sub partition_compare
 {
-    my ($a, $b) = @_;
-
     $a->devpath =~ m!\D(\d+)$!;
     my $an = $1;
     $b->devpath =~ m!\D(\d+)$!;
     my $bn = $1;
     return $an <=> $bn;
+}
+
+=pod
+
+=head2 partition_sort
+
+Return sorted C<NCM::Partition> instances (passed as arguments)
+in order of creation.
+
+=cut
+
+# Due to magic of sort global variables, make a function that sorts
+# instead of trying to get the comparison function working properly
+# outside this package
+
+sub partition_sort
+{
+    # Use array variable
+    my @sorted = sort {partition_compare()} @_;
+    return @sorted;
 }
 
 =pod

--- a/src/test/perl/partition_gpt.t
+++ b/src/test/perl/partition_gpt.t
@@ -1,10 +1,3 @@
-#!/usr/bin/perl 
-# -*- mode: cperl -*-
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-# ${build-info}
-
 use strict;
 use warnings;
 
@@ -12,11 +5,11 @@ use Test::More;
 use Test::Quattor qw(blockdevices_gpt);
 use helper;
 
-use NCM::Partition;
+use NCM::Partition qw(partition_sort);
 
-is(join(' ',NCM::Partition::PARTEDEXTRA), 'u MiB', "Always extra args 'u MiB' for parted");
+is(join(' ', NCM::Partition::PARTEDEXTRA), 'u MiB', "Always extra args 'u MiB' for parted");
 
-# the config has a "bug" in the sense that logical/extended partitions 
+# the config has a "bug" in the sense that logical/extended partitions
 # make no sense when using gpt (they are treated as names)
 # should still work though
 my $cfg = get_config_for_profile('blockdevices_gpt');
@@ -33,14 +26,14 @@ set_disks({sdb => 1});
 
 my $sdb1 = NCM::Partition->new ("/system/blockdevices/partitions/sdb1", $cfg);
 is ($sdb1->create, 0, "Partition $sdb1->{devname} on logical partitions test created correctly");
-is ($sdb1->begin, 0, 'Begin from 0 (no offset) for 1st partition'); 
+is ($sdb1->begin, 0, 'Begin from 0 (no offset) for 1st partition');
 set_output("parted_print_sdb_1prim_gpt"); # needed to update for begin/end calculations
 is($sdb1->{holding_dev}->partitions_in_disk, 1, "partition created correctly");
 
 set_output("parted_mkpart_sdb_prim2");
 my $sdb2 = NCM::Partition->new ("/system/blockdevices/partitions/sdb2", $cfg);
 is ($sdb2->create, 0, "Partition $sdb2->{devname} on logical partitions test created correctly");
-is ($sdb2->begin, 100, 'Begin from 0 (no offset) for 2nd partition'); 
+is ($sdb2->begin, 100, 'Begin from 0 (no offset) for 2nd partition');
 set_output("parted_print_sdb_2prim_gpt"); # needed to update for begin/end calculations
 is($sdb1->{holding_dev}, $sdb2->{holding_dev}, "Using the same disk instance sdb1 sdb2");
 is($sdb2->{holding_dev}->partitions_in_disk, 2, "partition created correctly");
@@ -48,7 +41,7 @@ is($sdb2->{holding_dev}->partitions_in_disk, 2, "partition created correctly");
 set_output("parted_mkpart_sdb_ext1");
 my $sdb3 = NCM::Partition->new ("/system/blockdevices/partitions/sdb3", $cfg);
 is ($sdb3->create, 0, "Partition $sdb3->{devname} on logical partitions test created correctly");
-is ($sdb3->begin, 200, 'Begin from 0 (no offset) for 3rd partition'); 
+is ($sdb3->begin, 200, 'Begin from 0 (no offset) for 3rd partition');
 set_output("parted_print_sdb_2prim_1ext_gpt"); # needed to update for begin/end calculations
 is($sdb1->{holding_dev}, $sdb3->{holding_dev}, "Using the same disk instance sdb1 sdb3");
 is($sdb2->{holding_dev}, $sdb3->{holding_dev}, "Using the same disk instance sdb2 sdb3");
@@ -57,7 +50,7 @@ is($sdb3->{holding_dev}->partitions_in_disk, 3, "partition created correctly");
 set_output("parted_mkpart_sdb_log1_gpt");
 my $sdb4 = NCM::Partition->new ("/system/blockdevices/partitions/sdb4", $cfg);
 is ($sdb4->create, 0, "Partition $sdb4->{devname} on logical partitions test created correctly");
-is ($sdb4->begin, 2700, 'Begin from 0 (no offset) for 4th partition'); 
+is ($sdb4->begin, 2700, 'Begin from 0 (no offset) for 4th partition');
 
 
 set_output("parted_print_sdb_2prim_1ext_1log_gpt"); # all partitions
@@ -82,6 +75,11 @@ ok(command_history_ok([
     '/sbin/parted -s -- /dev/sdb u MiB mkpart logical 2700 3724',
     ]), 'Command history gpt'
 );
+
+# partition_sort
+my @sorted = partition_sort($sdb4, $sdb2, $sdb3, $sdb1);
+is_deeply([map {$_->{devname}} @sorted], [qw(sdb1 sdb2 sdb3 sdb4)],
+          "partitions sorted as expected");
 
 
 done_testing();


### PR DESCRIPTION
This will break old code that uses `partition_compare` during import.
We can keep the old `partition_compare` code around, and export both new and old code; but the old perl code will not work with newer perl (it would require explicit prototypes; but it's far better to just export a sort function).