### PR TITLE
LV: add useexisting_lv flag and support useexisting option in ks

### DIFF
--- a/src/main/perl/LV.pm
+++ b/src/main/perl/LV.pm
@@ -39,6 +39,7 @@ use constant {
     LVM        => 'lvm',
     LVMFORCE   => '--force',
     AII_LVMFORCE_PATH => '/system/aii/osinstall/ks/lvmforce',
+    USEEXISTING       => '--useexisting',
 };
 
 use constant LVMWIPESIGNATURE => qw(-W y);
@@ -380,9 +381,20 @@ sub print_ks
     $self->{volume_group}->print_ks;
     print "\n";
 
+    my $useexisting = '';
+    # The useexisting_lv can be set by AII in ks.pm
+    if ($fs->{useexisting_lv}) {
+        $self->debug(5, 'useexisting flag enabled');
+        $useexisting = USEEXISTING;
+    }
+
     print join(" ",
-        "logvol", $fs->{mountpoint}, "--vgname=$self->{volume_group}->{devname}",
-        "--name=$self->{devname}", $self->ksfsformat($fs), "\n");
+               "logvol", $fs->{mountpoint},
+               "--vgname=$self->{volume_group}->{devname}",
+               "--name=$self->{devname}",
+               $self->ksfsformat($fs),
+               $useexisting,
+               "\n");
 }
 
 =pod

--- a/src/main/perl/MD.pm
+++ b/src/main/perl/MD.pm
@@ -282,6 +282,7 @@ sub print_ks
     return unless $self->should_print_ks;
 
     my $useexisting = '';
+    # The useexisting_md can be set by AII in ks.pm
     if ($fs->{useexisting_md}) {
         $self->debug(5, 'useexisting flag enabled');
         $useexisting = USEEXISTING;

--- a/src/test/perl/filesystem.t
+++ b/src/test/perl/filesystem.t
@@ -345,7 +345,15 @@ my $fs_md2 = NCM::Filesystem->new ("/system/filesystems/9", $cfg);
 select($fhfs_md2);
 ok(exists($fs_md2->{useexisting_md}), 'useexisting_md defined');
 $fs_md2->print_ks;
-is("$fhfs_md2", "raid /Lagoon --device=myname --noformat --useexisting \n", "useexisting ok");
+is("$fhfs_md2", "raid /Lagoon --device=myname --noformat --useexisting \n", "useexisting ok for MD");
+
+# lv test with useexisting for EL7
+my $fhfs_lv2 = CAF::FileWriter->new("target/test/ksfs_lv2");
+my $fs_lv2 = NCM::Filesystem->new ("/system/filesystems/10", $cfg);
+select($fhfs_lv2);
+ok(exists($fs_lv2->{useexisting_lv}), 'useexisting_lv defined');
+$fs_lv2->print_ks;
+is("$fhfs_lv2", "\nlogvol /Lagoon --vgname=vg0 --name=lv2 --noformat --useexisting \n", "useexisting ok for LV");
 
 # restore FH for DESTROY
 select($origfh);

--- a/src/test/resources/blockdevices.pan
+++ b/src/test/resources/blockdevices.pan
@@ -75,6 +75,10 @@ unique template blockdevices;
             "size", 800,
             "volume_group", "vg0"
             ),
+        "lv2", dict (
+            "size", 800,
+            "volume_group", "vg0"
+            ),
         ),
     "vxvm", dict(
         "vcslab.local", dict("gnr.0", dict(

--- a/src/test/resources/filesystems.pan
+++ b/src/test/resources/filesystems.pan
@@ -5,53 +5,57 @@ unique template filesystems;
     # always make a copy
 
     # apppend formattable/unpreserved fs
-    fs=value("/system/filesystems/0");
+    fs = value("/system/filesystems/0");
     fs["format"] = true;
     fs["preserve"] = false;
     append(fs);
 
     # append none type
-    fs=value("/system/filesystems/0");
-    fs["type"]="none";    
+    fs = value("/system/filesystems/0");
+    fs["type"]="none";
     append(fs);
 
     # append force_filesystem false
-    fs=value("/system/filesystems/0");
-    fs["force_filesystemtype"]=false;    
+    fs = value("/system/filesystems/0");
+    fs["force_filesystemtype"] = false;
     append(fs);
 
     # append force_filesystem true
-    fs=value("/system/filesystems/0");
-    fs["force_filesystemtype"]=true;    
+    fs = value("/system/filesystems/0");
+    fs["force_filesystemtype"] = true;
     append(fs);
 
     # append ksfsformat test
-    fs=value("/system/filesystems/0");
-    fs["ksfsformat"]=true;    
-    fs["mountopts"]="oneoption anotheroption";    
+    fs = value("/system/filesystems/0");
+    fs["ksfsformat"] = true;
+    fs["mountopts"] = "oneoption anotheroption";
     append(fs);
 
     # append md0 test
-    fs=value("/system/filesystems/0");
-    fs["block_device"]="md/md0";    
+    fs = value("/system/filesystems/0");
+    fs["block_device"] = "md/md0";
     append(fs);
 
     # append logvol test
-    fs=value("/system/filesystems/0");
-    fs["block_device"]="logical_volumes/lv0";    
+    fs = value("/system/filesystems/0");
+    fs["block_device"] = "logical_volumes/lv0";
     append(fs);
 
-    fs=value("/system/filesystems/0");
-    fs["block_device"]="logical_volumes/lv1";    
+    fs = value("/system/filesystems/0");
+    fs["block_device"] = "logical_volumes/lv1";
     fs["format"] = true;
     fs["preserve"] = false;
     append(fs);
 
     # append md test with useexisting
-    fs=value("/system/filesystems/0");
-    fs["block_device"]=format("md/%s", escape("md/myname"));    
+    fs = value("/system/filesystems/0");
+    fs["block_device"] = format("md/%s", escape("md/myname"));
     fs["useexisting_md"] = true;
     append(fs);
 
+    # append lv test with useexisting
+    fs = value("/system/filesystems/0");
+    fs["block_device"] = "logical_volumes/lv2";
+    fs["useexisting_lv"] = true;
+    append(fs);
 };
-


### PR DESCRIPTION
Partially fixes #82 (other part is AII PR https://github.com/quattor/aii/pull/281)