### PR TITLE
Running 'blkid' should be enabled in no-action mode

### DIFF
--- a/src/main/perl/Blockdevices.pm
+++ b/src/main/perl/Blockdevices.pm
@@ -499,7 +499,7 @@ sub get_uuid
     my ($self, $part) = @_;
     my $device = $self->devpath;
     my $uuid;
-    my $output = CAF::Process->new([BLKID, $device], log => $self)->output();
+    my $output = CAF::Process->new([BLKID, $device], log => $self, keeps_state => 1)->output();
     $part = $part ? 'PART' : '';
     my $re = qr!\s${part}UUID="(\S+)"!m ;
     if($output && $output =~ m/$re/m){


### PR DESCRIPTION
Otherwise, running "ncm-ncd --noaction --configure fstab" may always
complain about outstanding changes waiting to be applied, even when
ncm-ncd would not do anything when called without the --noaction flag.
Strictly speaking, blkid does maintain a cache, which may change
whenever blkid is called, but for all practical purposes, running blkid
should be safe.