### PR TITLE
MD: Don't specify chunk size when RAID level is 1

### DIFF
--- a/src/main/perl/MD.pm
+++ b/src/main/perl/MD.pm
@@ -360,12 +360,13 @@ EOC
         print "sed -i '\\:@{[$dev->devpath]}\$:d' @{[PART_FILE]}\n";
     }
     my $ndev = scalar(@devnames);
-    print <<EOC;
-    sleep 5; mdadm --create --run $path --level=$self->{raid_level} --metadata=$self->{metadata} \\
-        --chunk=$self->{stripe_size} --raid-devices=$ndev \\
-         @devnames
-    echo @{[$self->devpath]} >> @{[PART_FILE]}
-EOC
+    print "sleep 5;\n";
+    print "mdadm --create --run $path --level=$self->{raid_level} --metadata=$self->{metadata}";
+    if ($self->{raid_level} ne 1) {
+        print " --chunk=$self->{stripe_size}";
+    };
+    print " --raid-devices=$ndev @devnames\n";
+    print "echo @{[$self->devpath]} >> @{[PART_FILE]}\n";
     print "fi\n";
 }
 


### PR DESCRIPTION
It has no meaning anyway and causes mdadm to fail with an error in
recent versions.

Resolves issue #96.